### PR TITLE
Typo: unterlässlich should be changed to unerlässlich

### DIFF
--- a/_posts/2014-12-12-service-factory-provider.md
+++ b/_posts/2014-12-12-service-factory-provider.md
@@ -39,7 +39,7 @@ Natürlich lohnt sich ein Service weniger für einzelne Werte, sondern vor allem
 
 ## Was sind die Vorteile?
 
-Das Konzept von Services in AngularJS ist unterlässlich, wenn man eine große Anwendung in viele kleine sinnvolle Einheiten aufteilen möchte.
+Das Konzept von Services in AngularJS ist unerlässlich, wenn man eine große Anwendung in viele kleine sinnvolle Einheiten aufteilen möchte.
 Im besten Fall erreicht man damit, dass eine komplexe und weiter wachsende Anwendung trotzdem erweiterbar und wartbar bleibt, ohne dass sich jede Änderung anfühlt, wie das Herausziehen eines Bausteins aus einem Jenga-Turm.
 Vor allem sehr große Controller-Methoden sind ein Warnzeichen für zu unzureichende Strukturierung der Anwendungslogik.
 


### PR DESCRIPTION
Unterlässlich isn't a german word. The correct word should be "unerlässlich".