### PR TITLE
Fix stylesheet

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,3 +1,5 @@
+---
+---
 $font-family-sans-serif:  "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 $navbar-brand-font-size: 1rem;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,5 +1,7 @@
 ---
 ---
+// 🔝 those lines above are needed by jekyll
+
 $font-family-sans-serif:  "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 $navbar-brand-font-size: 1rem;


### PR DESCRIPTION
The stylesheet was broken after deploying 21d646967d86076be741d72d88eb3589a8834382. Those weird lines at the beginning of the `app.scss` file are required by https://github.com/jekyll/jekyll-help/issues/104#issuecomment-50481229.

I added a hint so that the next person who wants to remove the lines knows that they are needed. I didn't find any way to exclude them in scss-linters 😞
  